### PR TITLE
 Feat: Complete Backend Setup for HueBot

### DIFF
--- a/HueBot/server/.env.example
+++ b/HueBot/server/.env.example
@@ -1,3 +1,4 @@
 PORT=port_number
 MONGODB_URI=your_mongodb_connection_string
+JWT_SECRET=your_jwt_secret_key
 NODE_ENV=environment_type

--- a/HueBot/server/controllers/authController.js
+++ b/HueBot/server/controllers/authController.js
@@ -54,3 +54,47 @@ exports.register = async (req, res) => {
     res.status(500).json({ message: "Server error" });
   }
 };
+
+// Login user
+exports.login = async (req, res) => {
+  try {
+    // Validate input
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password } = req.body;
+
+    // Check if user exists
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(400).json({ message: "Invalid credentials" });
+    }
+
+    // Check password
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ message: "Invalid credentials" });
+    }
+
+    // Create JWT token
+    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
+      expiresIn: "7d",
+    });
+
+    res.json({
+      message: "Login successful",
+      token,
+      user: {
+        id: user._id,
+        name: user.name,
+        username: user.username,
+        email: user.email,
+      },
+    });
+  } catch (error) {
+    console.error("Login error:", error);
+    res.status(500).json({ message: "Server error" });
+  }
+};

--- a/HueBot/server/controllers/authController.js
+++ b/HueBot/server/controllers/authController.js
@@ -1,0 +1,56 @@
+const bcrypt = require("bcryptjs");
+const jwt = require("jsonwebtoken");
+const { validationResult } = require("express-validator");
+const User = require("../models/User");
+
+// Register new user
+exports.register = async (req, res) => {
+  try {
+    // Validate input
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { name, username, email, password } = req.body;
+
+    // Check if user already exists
+    let user = await User.findOne({ $or: [{ email }, { username }] });
+    if (user) {
+      return res.status(400).json({ message: "User already exists" });
+    }
+
+    // Hash password
+    const salt = await bcrypt.genSalt(10);
+    const hashedPassword = await bcrypt.hash(password, salt);
+
+    // Create new user
+    user = new User({
+      name,
+      username,
+      email,
+      password: hashedPassword,
+    });
+
+    await user.save();
+
+    // Create JWT token
+    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
+      expiresIn: "15d",
+    });
+
+    res.status(201).json({
+      message: "User registered successfully",
+      token,
+      user: {
+        id: user._id,
+        name: user.name,
+        username: user.username,
+        email: user.email,
+      },
+    });
+  } catch (error) {
+    console.error("Register error:", error);
+    res.status(500).json({ message: "Server error" });
+  }
+};

--- a/HueBot/server/controllers/paletteController.js
+++ b/HueBot/server/controllers/paletteController.js
@@ -1,0 +1,63 @@
+const Palette = require("../models/Palette");
+
+// Get all colour palettes for logged in user
+exports.getPalettes = async (req, res) => {
+  try {
+    const palettes = await Palette.find({ user: req.userId }).sort({
+      createdAt: -1,
+    });
+    res.json(palettes);
+  } catch (error) {
+    console.error("Get palettes error:", error);
+    res.status(500).json({ message: "Server error" });
+  }
+};
+
+// Save a new colour palette
+exports.savePalette = async (req, res) => {
+  try {
+    const { name, colors } = req.body;
+
+    // Validate input
+    if (!name || !colors || !Array.isArray(colors) || colors.length === 0) {
+      return res.status(400).json({ message: "Name and colors are required" });
+    }
+
+    // Create new colour palette
+    const palette = new Palette({
+      user: req.userId,
+      name,
+      colors,
+    });
+
+    await palette.save();
+
+    res.status(201).json({
+      message: "Palette saved successfully",
+      palette,
+    });
+  } catch (error) {
+    console.error("Save palette error:", error);
+    res.status(500).json({ message: "Server error" });
+  }
+};
+
+// Delete a colour palette
+exports.deletePalette = async (req, res) => {
+  try {
+    const palette = await Palette.findOne({
+      _id: req.params.id,
+      user: req.userId,
+    });
+
+    if (!palette) {
+      return res.status(404).json({ message: "Palette not found" });
+    }
+
+    await Palette.deleteOne({ _id: req.params.id });
+    res.json({ message: "Palette deleted successfully" });
+  } catch (error) {
+    console.error("Delete palette error:", error);
+    res.status(500).json({ message: "Server error" });
+  }
+};

--- a/HueBot/server/middleware/auth.js
+++ b/HueBot/server/middleware/auth.js
@@ -1,0 +1,23 @@
+const jwt = require("jsonwebtoken");
+
+const auth = async (req, res, next) => {
+  try {
+    // Get token from header
+    const token = req.header("Authorization")?.replace("Bearer ", "");
+
+    if (!token) {
+      return res
+        .status(401)
+        .json({ message: "No token, authorization denied" });
+    }
+
+    // Verify token
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.userId = decoded.userId;
+    next();
+  } catch (error) {
+    res.status(401).json({ message: "Token is not valid" });
+  }
+};
+
+module.exports = auth;

--- a/HueBot/server/routes/auth.js
+++ b/HueBot/server/routes/auth.js
@@ -1,0 +1,34 @@
+const express = require("express");
+const { body } = require("express-validator");
+const { register, login } = require("../controllers/authController");
+
+const router = express.Router();
+
+// Register route
+router.post(
+  "/register",
+  [
+    body("name").trim().notEmpty().withMessage("Name is required"),
+    body("username")
+      .trim()
+      .isLength({ min: 3 })
+      .withMessage("Username must be at least 3 characters"),
+    body("email").isEmail().withMessage("Please enter a valid email"),
+    body("password")
+      .isLength({ min: 6 })
+      .withMessage("Password must be at least 6 characters"),
+  ],
+  register
+);
+
+// Login route
+router.post(
+  "/login",
+  [
+    body("email").isEmail().withMessage("Please enter a valid email"),
+    body("password").notEmpty().withMessage("Password is required"),
+  ],
+  login
+);
+
+module.exports = router;

--- a/HueBot/server/routes/palette.js
+++ b/HueBot/server/routes/palette.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const auth = require("../middleware/auth");
+const {
+  getPalettes,
+  savePalette,
+  deletePalette,
+} = require("../controllers/paletteController");
+
+const router = express.Router();
+
+// All routes are protected with auth middleware
+router.get("/", auth, getPalettes);
+router.post("/", auth, savePalette);
+router.delete("/:id", auth, deletePalette);
+
+module.exports = router;

--- a/HueBot/server/server.js
+++ b/HueBot/server/server.js
@@ -15,6 +15,7 @@ app.use(express.json());
 
 // Routes
 app.use("/api/auth", require("./routes/auth"));
+app.use("/api/palettes", require("./routes/palette"));
 
 // Status check endpoint
 app.get("/", (req, res) => {

--- a/HueBot/server/server.js
+++ b/HueBot/server/server.js
@@ -13,6 +13,14 @@ connectDB();
 app.use(cors());
 app.use(express.json());
 
+// Routes
+app.use("/api/auth", require("./routes/auth"));
+
+// Status check endpoint
+app.get("/", (req, res) => {
+  res.json({ message: "HueBot API is running" });
+});
+
 // Start server
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {


### PR DESCRIPTION
**Summary:**
This PR implements the complete backend setup for HueBot, including:

- Authentication (registration & login, JWT-based auth)
- Palette Controller (CRUD operations for colour palettes)

Authenticated users can now:
- [x] Create a new palette
- [x] Read their palettes
- [x] Delete a palette
- [ ] Update existing palette

I have verified each and every endpoints manually with `Postman`

_Note: Will implement update functonality in future as the project doesnt demand it now

**Issue Addressed:** #16 

@ianshulx 