### PR TITLE
Feat: Allow authenticated users to save, view & delete color palettes

### DIFF
--- a/HueBot/client/src/App.css
+++ b/HueBot/client/src/App.css
@@ -25,12 +25,24 @@
 .user-info {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
-.user-info span {
-  color: var(--text-secondary);
-  font-size: 0.95rem;
+.my-hues-btn {
+  padding: 0.7rem 1.5rem;
+  border: 2px solid var(--orange);
+  border-radius: 10px;
+  background: white;
+  color: var(--orange);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.my-hues-btn:hover {
+  background: var(--orange);
+  color: white;
+  transform: translateY(-1px);
 }
 
 .logout-btn {

--- a/HueBot/client/src/App.css
+++ b/HueBot/client/src/App.css
@@ -8,7 +8,7 @@
   justify-content: space-between;
   align-items: center;
   max-width: 1400px;
-  margin: 0 auto 4rem;
+  margin: 0 auto 2rem;
   padding: 1.5rem 2rem;
   background: var(--bg-card);
   border: 2px solid var(--border);

--- a/HueBot/client/src/App.jsx
+++ b/HueBot/client/src/App.jsx
@@ -1,11 +1,17 @@
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { AuthContext } from "./context/AuthContext";
 import Auth from "./components/Auth";
 import PaletteGenerator from "./components/PaletteGenerator";
+import SavedPalettes from "./components/SavedPalettes";
 import "./App.css";
 
 function App() {
   const { isAuthenticated, user, logout } = useContext(AuthContext);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  const triggerRefresh = () => {
+    setRefreshTrigger((prev) => prev + 1);
+  };
 
   if (!isAuthenticated) {
     return <Auth />;
@@ -22,7 +28,8 @@ function App() {
           </button>
         </div>
       </div>
-      <PaletteGenerator />
+      <PaletteGenerator onPaletteSaved={triggerRefresh} />
+      <SavedPalettes refreshTrigger={refreshTrigger} />
     </div>
   );
 }

--- a/HueBot/client/src/App.jsx
+++ b/HueBot/client/src/App.jsx
@@ -8,6 +8,7 @@ import "./App.css";
 function App() {
   const { isAuthenticated, user, logout } = useContext(AuthContext);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [showMyHues, setShowMyHues] = useState(false);
 
   const triggerRefresh = () => {
     setRefreshTrigger((prev) => prev + 1);
@@ -22,14 +23,22 @@ function App() {
       <div className="header">
         <h1>HueBot</h1>
         <div className="user-info">
-          <span>Hello, {user?.name}!</span>
+          <button
+            onClick={() => setShowMyHues(!showMyHues)}
+            className="my-hues-btn"
+          >
+            {showMyHues ? "Generate" : "My Hues"}
+          </button>
           <button onClick={logout} className="logout-btn">
             Logout
           </button>
         </div>
       </div>
-      <PaletteGenerator onPaletteSaved={triggerRefresh} />
-      <SavedPalettes refreshTrigger={refreshTrigger} />
+      {showMyHues ? (
+        <SavedPalettes refreshTrigger={refreshTrigger} userName={user?.name} />
+      ) : (
+        <PaletteGenerator onPaletteSaved={triggerRefresh} />
+      )}
     </div>
   );
 }

--- a/HueBot/client/src/components/PaletteGenerator.css
+++ b/HueBot/client/src/components/PaletteGenerator.css
@@ -86,18 +86,26 @@
 }
 
 .colour-code {
-  background: rgba(0, 0, 0, 0.7);
-  color: white;
-  padding: 0.5rem 1rem;
+  background: white;
+  color: var(--text-primary);
+  padding: 0.6rem 1.2rem;
   border-radius: 8px;
+  border: 2px solid var(--border);
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: all 0.2s ease;
+  text-align: center;
+  min-width: 100px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .colour-box:hover .colour-code {
   opacity: 1;
+}
+
+.colour-box:active .colour-code {
+  opacity: 0.7;
 }
 
 .generate-btn {

--- a/HueBot/client/src/components/PaletteGenerator.css
+++ b/HueBot/client/src/components/PaletteGenerator.css
@@ -1,7 +1,7 @@
 .palette-generator {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0 2rem 2rem;
   position: relative;
 }
 
@@ -35,7 +35,7 @@
   gap: 1rem;
   justify-content: center;
   flex-wrap: wrap;
-  margin-bottom: 3rem;
+  margin-bottom: 2.5rem;
 }
 
 .palette-controls button {
@@ -109,7 +109,7 @@
 }
 
 .generate-btn {
-  padding: 1rem 3rem;
+  padding: 1rem 2.5rem;
   border: none;
   border-radius: 12px;
   background: var(--orange);
@@ -133,7 +133,7 @@
 }
 
 .save-btn {
-  padding: 1rem 3rem;
+  padding: 1rem 2.5rem;
   border: 2px solid var(--orange);
   border-radius: 12px;
   background: white;

--- a/HueBot/client/src/components/PaletteGenerator.css
+++ b/HueBot/client/src/components/PaletteGenerator.css
@@ -1,5 +1,5 @@
 .palette-generator {
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
   padding: 0 2rem 2rem;
   position: relative;
@@ -7,7 +7,7 @@
 
 .message-toast {
   position: fixed;
-  top: 2rem;
+  bottom: 2rem;
   right: 2rem;
   background: var(--orange);
   color: white;
@@ -15,17 +15,17 @@
   border-radius: 10px;
   font-weight: 600;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  animation: slideIn 0.3s ease;
+  animation: slideInBottom 0.3s ease;
   z-index: 1000;
 }
 
-@keyframes slideIn {
+@keyframes slideInBottom {
   from {
-    transform: translateX(100%);
+    transform: translateY(100%);
     opacity: 0;
   }
   to {
-    transform: translateX(0);
+    transform: translateY(0);
     opacity: 1;
   }
 }
@@ -64,8 +64,8 @@
 .palette-display {
   display: flex;
   gap: 1rem;
-  margin-bottom: 3rem;
-  min-height: 300px;
+  margin-bottom: 2.5rem;
+  min-height: 400px;
 }
 
 .colour-box {
@@ -161,6 +161,7 @@
   align-items: center;
   justify-content: center;
   z-index: 999;
+  animation: overlayFadeIn 0.2s ease-in;
 }
 
 .modal-content {
@@ -168,14 +169,17 @@
   padding: 2.5rem;
   border-radius: 16px;
   width: 90%;
-  max-width: 400px;
+  max-width: 450px;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--orange);
+  animation: popIn 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
 
 .modal-content h3 {
   margin: 0 0 1.5rem 0;
-  color: var(--text-primary);
+  color: var(--orange);
   font-size: 1.5rem;
+  text-align: center;
 }
 
 .modal-content input {
@@ -184,8 +188,9 @@
   border: 2px solid var(--border);
   border-radius: 10px;
   font-size: 1rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0;
   transition: border-color 0.2s ease;
+  text-align: center;
 }
 
 .modal-content input:focus {
@@ -196,12 +201,13 @@
 .modal-actions {
   display: flex;
   gap: 1rem;
-  justify-content: flex-end;
+  margin-top: 1.5rem;
+  justify-content: center;
 }
 
 .modal-actions button {
-  padding: 0.75rem 1.75rem;
-  border: none;
+  flex: 1;
+  padding: 0.75rem;
   border-radius: 10px;
   font-weight: 600;
   font-size: 1rem;
@@ -210,27 +216,51 @@
 }
 
 .modal-actions button:first-child {
-  background: transparent;
-  color: var(--text-secondary);
+  background: white;
+  color: var(--text-primary);
   border: 2px solid var(--border);
 }
 
 .modal-actions button:first-child:hover {
-  background: var(--bg-primary);
+  background: #f3f4f6;
+  transform: translateY(-1px);
 }
 
 .modal-actions button:last-child {
   background: var(--orange);
   color: white;
+  border: 2px solid var(--orange);
 }
 
 .modal-actions button:last-child:hover:not(:disabled) {
   background: var(--orange-dark);
+  border-color: var(--orange-dark);
+  transform: translateY(-1px);
 }
 
 .modal-actions button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @media (max-width: 768px) {

--- a/HueBot/client/src/components/PaletteGenerator.css
+++ b/HueBot/client/src/components/PaletteGenerator.css
@@ -2,6 +2,32 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: 2rem;
+  position: relative;
+}
+
+.message-toast {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  background: var(--orange);
+  color: white;
+  padding: 1rem 1.5rem;
+  border-radius: 10px;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  animation: slideIn 0.3s ease;
+  z-index: 1000;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 .palette-controls {
@@ -75,8 +101,6 @@
 }
 
 .generate-btn {
-  display: block;
-  margin: 0 auto;
   padding: 1rem 3rem;
   border: none;
   border-radius: 12px;
@@ -91,6 +115,114 @@
 .generate-btn:hover {
   background: var(--orange-dark);
   transform: translateY(-2px);
+}
+
+.action-buttons {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.save-btn {
+  padding: 1rem 3rem;
+  border: 2px solid var(--orange);
+  border-radius: 12px;
+  background: white;
+  color: var(--orange);
+  font-size: 1.1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.save-btn:hover {
+  background: var(--orange);
+  color: white;
+  transform: translateY(-2px);
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.modal-content {
+  background: white;
+  padding: 2.5rem;
+  border-radius: 16px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+}
+
+.modal-content h3 {
+  margin: 0 0 1.5rem 0;
+  color: var(--text-primary);
+  font-size: 1.5rem;
+}
+
+.modal-content input {
+  width: 100%;
+  padding: 0.9rem;
+  border: 2px solid var(--border);
+  border-radius: 10px;
+  font-size: 1rem;
+  margin-bottom: 1.5rem;
+  transition: border-color 0.2s ease;
+}
+
+.modal-content input:focus {
+  outline: none;
+  border-color: var(--orange);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+.modal-actions button {
+  padding: 0.75rem 1.75rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.modal-actions button:first-child {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 2px solid var(--border);
+}
+
+.modal-actions button:first-child:hover {
+  background: var(--bg-primary);
+}
+
+.modal-actions button:last-child {
+  background: var(--orange);
+  color: white;
+}
+
+.modal-actions button:last-child:hover:not(:disabled) {
+  background: var(--orange-dark);
+}
+
+.modal-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 @media (max-width: 768px) {

--- a/HueBot/client/src/components/PaletteGenerator.jsx
+++ b/HueBot/client/src/components/PaletteGenerator.jsx
@@ -136,10 +136,10 @@ const PaletteGenerator = ({ onPaletteSaved }) => {
           className="generate-btn"
           onClick={() => handleGenerate(paletteType)}
         >
-          Generate New Palette
+          Generate
         </button>
         <button className="save-btn" onClick={() => setShowSaveModal(true)}>
-          Save Palette
+          Save
         </button>
       </div>
 

--- a/HueBot/client/src/components/PaletteGenerator.jsx
+++ b/HueBot/client/src/components/PaletteGenerator.jsx
@@ -9,7 +9,7 @@ import {
 } from "../utils/colourGenerator";
 import { paletteAPI } from "../services/api";
 
-const PaletteGenerator = () => {
+const PaletteGenerator = ({ onPaletteSaved }) => {
   const [palette, setPalette] = useState(generateRandomPalette());
   const [paletteType, setPaletteType] = useState("random");
   const [showSaveModal, setShowSaveModal] = useState(false);
@@ -66,10 +66,13 @@ const PaletteGenerator = () => {
         setPaletteName("");
         setShowSaveModal(false);
         setTimeout(() => setMessage(""), 3000);
+        if (onPaletteSaved) {
+          onPaletteSaved();
+        }
       } else {
         setMessage(response.message || "Failed to save palette");
       }
-    } catch (error) {
+    } catch {
       setMessage("Error saving palette");
     } finally {
       setSaving(false);

--- a/HueBot/client/src/components/PaletteGenerator.jsx
+++ b/HueBot/client/src/components/PaletteGenerator.jsx
@@ -62,7 +62,7 @@ const PaletteGenerator = ({ onPaletteSaved }) => {
       });
 
       if (response.palette) {
-        setMessage("Palette saved successfully!");
+        setMessage("🎉 Palette saved successfully!");
         setPaletteName("");
         setShowSaveModal(false);
         setTimeout(() => setMessage(""), 3000);
@@ -136,10 +136,10 @@ const PaletteGenerator = ({ onPaletteSaved }) => {
           className="generate-btn"
           onClick={() => handleGenerate(paletteType)}
         >
-          Generate
+          Generate New
         </button>
         <button className="save-btn" onClick={() => setShowSaveModal(true)}>
-          Save
+          Save Palette
         </button>
       </div>
 

--- a/HueBot/client/src/components/PaletteGenerator.jsx
+++ b/HueBot/client/src/components/PaletteGenerator.jsx
@@ -16,9 +16,11 @@ const PaletteGenerator = () => {
   const [paletteName, setPaletteName] = useState("");
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
+  const [copiedIndex, setCopiedIndex] = useState(null);
 
   const handleGenerate = (type) => {
     setPaletteType(type);
+    setCopiedIndex(null);
     switch (type) {
       case "random":
         setPalette(generateRandomPalette());
@@ -40,10 +42,10 @@ const PaletteGenerator = () => {
     }
   };
 
-  const copyToClipboard = (colour) => {
+  const copyToClipboard = (colour, index) => {
     navigator.clipboard.writeText(colour);
-    setMessage(`Copied ${colour}!`);
-    setTimeout(() => setMessage(""), 2000);
+    setCopiedIndex(index);
+    setTimeout(() => setCopiedIndex(null), 1500);
   };
 
   const handleSave = async () => {
@@ -60,7 +62,7 @@ const PaletteGenerator = () => {
       });
 
       if (response.palette) {
-        setMessage("Palette saved successfully! 🎉");
+        setMessage("Palette saved successfully!");
         setPaletteName("");
         setShowSaveModal(false);
         setTimeout(() => setMessage(""), 3000);
@@ -117,9 +119,11 @@ const PaletteGenerator = () => {
             key={index}
             className="colour-box"
             style={{ backgroundColor: colour }}
-            onClick={() => copyToClipboard(colour)}
+            onClick={() => copyToClipboard(colour, index)}
           >
-            <span className="colour-code">{colour}</span>
+            <span className="colour-code">
+              {copiedIndex === index ? "Copied!" : colour}
+            </span>
           </div>
         ))}
       </div>

--- a/HueBot/client/src/components/SavedPalettes.css
+++ b/HueBot/client/src/components/SavedPalettes.css
@@ -1,13 +1,26 @@
 .saved-palettes {
-  margin-top: 3rem;
+  margin-top: 0;
   padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.saved-palettes-header {
+  text-align: center;
+  margin-bottom: 2rem;
 }
 
 .saved-palettes h2 {
   color: var(--orange);
   font-size: 1.8rem;
-  margin-bottom: 1.5rem;
-  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.palette-count {
+  color: #666;
+  font-size: 0.95rem;
+  font-weight: 500;
+  margin: 0;
 }
 
 .saved-palettes-loading,
@@ -30,7 +43,7 @@
 
 .palettes-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   gap: 1.5rem;
 }
 
@@ -90,12 +103,14 @@
 
 .palette-colours {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 0.75rem;
 }
 
 .colour-box-small {
-  flex: 1;
+  flex: 1 1 calc(20% - 0.5rem);
+  min-width: 50px;
   height: 80px;
   border-radius: 8px;
   cursor: pointer;
@@ -106,6 +121,7 @@
   justify-content: center;
   transition: transform 0.2s, opacity 0.2s;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
 }
 
 .colour-box-small:hover {
@@ -118,12 +134,16 @@
 
 .hex-code-small {
   color: white;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 600;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
   background: rgba(0, 0, 0, 0.2);
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem 0.4rem;
   border-radius: 4px;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .copied-badge-small {
@@ -147,6 +167,129 @@
   color: #999;
   font-size: 0.85rem;
   margin-top: 0.5rem;
+}
+
+.delete-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: overlayFadeIn 0.2s ease-in;
+}
+
+.delete-modal-content {
+  background: var(--bg-card);
+  border-radius: 16px;
+  padding: 2rem;
+  max-width: 450px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--orange);
+  animation: popIn 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  text-align: center;
+}
+
+.delete-modal-content h3 {
+  color: var(--orange);
+  font-size: 1.5rem;
+  margin: 0 0 1rem 0;
+  text-align: center;
+}
+
+.delete-modal-content p {
+  color: #333;
+  font-size: 1rem;
+  margin: 0.5rem 0;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.delete-modal-content p strong {
+  color: var(--orange);
+}
+
+.delete-warning {
+  color: #666;
+  font-size: 0.9rem;
+  font-style: italic;
+  margin-top: 1rem !important;
+}
+
+.delete-modal-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  justify-content: center;
+}
+
+.cancel-btn,
+.confirm-delete-btn {
+  padding: 0.7rem 1.5rem;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 0.95rem;
+}
+
+.cancel-btn {
+  background: white;
+  border: 2px solid var(--border);
+  color: var(--text-primary);
+}
+
+.cancel-btn:hover {
+  background: #f3f4f6;
+  transform: translateY(-1px);
+}
+
+.confirm-delete-btn {
+  background: #ef4444;
+  border: 2px solid #ef4444;
+  color: white;
+}
+
+.confirm-delete-btn:hover {
+  background: #dc2626;
+  border-color: #dc2626;
+  transform: translateY(-1px);
+}
+
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes fadeIn {

--- a/HueBot/client/src/components/SavedPalettes.css
+++ b/HueBot/client/src/components/SavedPalettes.css
@@ -1,0 +1,179 @@
+.saved-palettes {
+  margin-top: 3rem;
+  padding: 2rem;
+}
+
+.saved-palettes h2 {
+  color: var(--orange);
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.saved-palettes-loading,
+.saved-palettes-error,
+.saved-palettes-empty {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+
+.saved-palettes-error {
+  color: #ef4444;
+}
+
+.saved-palettes-empty p:first-child {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.palettes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.palette-card {
+  background: var(--bg-card);
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.palette-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.palette-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.palette-card h3 {
+  color: #333;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.delete-btn {
+  background: transparent;
+  border: none;
+  color: #999;
+  font-size: 1.8rem;
+  cursor: pointer;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.2s;
+  line-height: 1;
+}
+
+.delete-btn:hover {
+  background: #fee2e2;
+  color: #ef4444;
+}
+
+.palette-colours {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.colour-box-small {
+  flex: 1;
+  height: 80px;
+  border-radius: 8px;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s, opacity 0.2s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.colour-box-small:hover {
+  transform: scale(1.05);
+}
+
+.colour-box-small:active {
+  opacity: 0.7;
+}
+
+.hex-code-small {
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.2);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+.copied-badge-small {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  color: var(--orange);
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--orange);
+  animation: fadeIn 0.2s ease-in;
+}
+
+.palette-date {
+  text-align: right;
+  color: #999;
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@media (max-width: 768px) {
+  .saved-palettes {
+    padding: 1rem;
+  }
+
+  .palettes-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .colour-box-small {
+    height: 60px;
+  }
+
+  .hex-code-small {
+    font-size: 0.7rem;
+  }
+}

--- a/HueBot/client/src/components/SavedPalettes.css
+++ b/HueBot/client/src/components/SavedPalettes.css
@@ -184,30 +184,33 @@
 }
 
 .delete-modal-content {
-  background: var(--bg-card);
+  background: white;
   border-radius: 16px;
-  padding: 2rem;
+  padding: 2.5rem;
   max-width: 450px;
   width: 90%;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
   border: 2px solid var(--orange);
   animation: popIn 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-  text-align: center;
 }
 
 .delete-modal-content h3 {
   color: var(--orange);
   font-size: 1.5rem;
-  margin: 0 0 1rem 0;
+  margin: 0 0 1.5rem 0;
   text-align: center;
 }
 
 .delete-modal-content p {
   color: #333;
   font-size: 1rem;
-  margin: 0.5rem 0;
-  line-height: 1.5;
+  margin: 0;
+  line-height: 1.6;
   text-align: center;
+}
+
+.delete-modal-content p:not(:last-of-type) {
+  margin-bottom: 0.5rem;
 }
 
 .delete-modal-content p strong {
@@ -218,7 +221,8 @@
   color: #666;
   font-size: 0.9rem;
   font-style: italic;
-  margin-top: 1rem !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
 }
 
 .delete-modal-actions {
@@ -230,12 +234,13 @@
 
 .cancel-btn,
 .confirm-delete-btn {
-  padding: 0.7rem 1.5rem;
+  flex: 1;
+  padding: 0.75rem;
   border-radius: 10px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
-  font-size: 0.95rem;
+  font-size: 1rem;
 }
 
 .cancel-btn {

--- a/HueBot/client/src/components/SavedPalettes.jsx
+++ b/HueBot/client/src/components/SavedPalettes.jsx
@@ -1,0 +1,115 @@
+import { useState, useEffect } from "react";
+import { paletteAPI } from "../services/api";
+import "./SavedPalettes.css";
+
+const SavedPalettes = ({ refreshTrigger }) => {
+  const [palettes, setPalettes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [copiedColor, setCopiedColor] = useState(null);
+
+  useEffect(() => {
+    fetchPalettes();
+  }, [refreshTrigger]);
+
+  const fetchPalettes = async () => {
+    try {
+      setLoading(true);
+      const data = await paletteAPI.getAll();
+      if (data.success) {
+        setPalettes(data.palettes);
+      } else {
+        setError(data.message);
+      }
+    } catch {
+      setError("Failed to fetch palettes");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (paletteId) => {
+    if (!window.confirm("Are you sure you want to delete this palette?")) {
+      return;
+    }
+
+    try {
+      const data = await paletteAPI.delete(paletteId);
+      if (data.success) {
+        setPalettes(palettes.filter((p) => p._id !== paletteId));
+      } else {
+        setError(data.message);
+      }
+    } catch {
+      setError("Failed to delete palette");
+    }
+  };
+
+  const copyToClipboard = (color, paletteId) => {
+    navigator.clipboard.writeText(color);
+    setCopiedColor(`${paletteId}-${color}`);
+    setTimeout(() => setCopiedColor(null), 1500);
+  };
+
+  if (loading) {
+    return (
+      <div className="saved-palettes-loading">Loading your palettes...</div>
+    );
+  }
+
+  if (error) {
+    return <div className="saved-palettes-error">{error}</div>;
+  }
+
+  if (palettes.length === 0) {
+    return (
+      <div className="saved-palettes-empty">
+        <p>No saved palettes yet!</p>
+        <p>Generate and save some beautiful colour combinations above.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="saved-palettes">
+      <h2>Your Saved Palettes</h2>
+      <div className="palettes-grid">
+        {palettes.map((palette) => (
+          <div key={palette._id} className="palette-card">
+            <div className="palette-card-header">
+              <h3>{palette.name}</h3>
+              <button
+                onClick={() => handleDelete(palette._id)}
+                className="delete-btn"
+                title="Delete palette"
+              >
+                ×
+              </button>
+            </div>
+            <div className="palette-colours">
+              {palette.colors.map((color, index) => (
+                <div
+                  key={index}
+                  className="colour-box-small"
+                  style={{ backgroundColor: color }}
+                  onClick={() => copyToClipboard(color, palette._id)}
+                  title={`Click to copy ${color}`}
+                >
+                  <span className="hex-code-small">{color}</span>
+                  {copiedColor === `${palette._id}-${color}` && (
+                    <span className="copied-badge-small">Copied!</span>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="palette-date">
+              {new Date(palette.createdAt).toLocaleDateString()}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SavedPalettes;

--- a/HueBot/client/src/components/SavedPalettes.jsx
+++ b/HueBot/client/src/components/SavedPalettes.jsx
@@ -12,7 +12,6 @@ const SavedPalettes = ({ refreshTrigger, userName }) => {
     palette: null,
   });
 
-  // Get first name only
   const firstName = userName ? userName.split(" ")[0] : null;
 
   useEffect(() => {
@@ -138,11 +137,8 @@ const SavedPalettes = ({ refreshTrigger, userName }) => {
             onClick={(e) => e.stopPropagation()}
           >
             <h3>Delete Palette</h3>
-            <p>
-              Are you sure you want to delete{" "}
-              <strong>{deleteModal.palette?.name}</strong>?
-            </p>
-            <p className="delete-warning">This action cannot be undone.</p>
+            <p>Are you sure you want to delete</p>
+            <p className="delete-warning">{deleteModal.palette?.name}?</p>
             <div className="delete-modal-actions">
               <button onClick={closeDeleteModal} className="cancel-btn">
                 Cancel

--- a/HueBot/server/controllers/paletteController.js
+++ b/HueBot/server/controllers/paletteController.js
@@ -6,10 +6,10 @@ exports.getPalettes = async (req, res) => {
     const palettes = await Palette.find({ user: req.userId }).sort({
       createdAt: -1,
     });
-    res.json(palettes);
+    res.json({ success: true, palettes });
   } catch (error) {
     console.error("Get palettes error:", error);
-    res.status(500).json({ message: "Server error" });
+    res.status(500).json({ success: false, message: "Server error" });
   }
 };
 
@@ -33,12 +33,13 @@ exports.savePalette = async (req, res) => {
     await palette.save();
 
     res.status(201).json({
+      success: true,
       message: "Palette saved successfully",
       palette,
     });
   } catch (error) {
     console.error("Save palette error:", error);
-    res.status(500).json({ message: "Server error" });
+    res.status(500).json({ success: false, message: "Server error" });
   }
 };
 
@@ -51,13 +52,15 @@ exports.deletePalette = async (req, res) => {
     });
 
     if (!palette) {
-      return res.status(404).json({ message: "Palette not found" });
+      return res
+        .status(404)
+        .json({ success: false, message: "Palette not found" });
     }
 
     await Palette.deleteOne({ _id: req.params.id });
-    res.json({ message: "Palette deleted successfully" });
+    res.json({ success: true, message: "Palette deleted successfully" });
   } catch (error) {
     console.error("Delete palette error:", error);
-    res.status(500).json({ message: "Server error" });
+    res.status(500).json({ success: false, message: "Server error" });
   }
 };


### PR DESCRIPTION
**Summary:**
This PR adds the ability for authenticated users to save their favorite color palettes and view them later. Users can now generate palettes, save them with custom names and manage their collection through a dedicated "My Hues" view.

**Key Features Added:**
- [x] Save palette functionality with custom naming modal
- [x] Saved palettes display page with responsive grid layout
- [x] Delete saved palettes with confirmation modal
- [x] Toggle between palette generator and saved palettes view
- [x] Keyboard shortcut (spacebar) to generate new palettes
- [x] Copy individual colors from palettes with just a click

**Screenshots:**
<img width="1920" height="1080" alt="Screenshot (335)" src="https://github.com/user-attachments/assets/78a9d0af-cec0-40f5-957a-1a71ca66e4eb" />
<img width="1920" height="1080" alt="Screenshot (337)" src="https://github.com/user-attachments/assets/3e2250ab-3d5f-461d-aab5-18497fca176c" />
<img width="1920" height="1080" alt="Screenshot (338)" src="https://github.com/user-attachments/assets/d9c9f501-1f58-4553-ad7b-d1482c0d5d8d" />
<img width="1920" height="1080" alt="Screenshot (339)" src="https://github.com/user-attachments/assets/24f9545e-bcb7-4c9f-9ea1-95fb1b5b8f7c" />

This PR addresses issue #16

@ianshulx  review!
